### PR TITLE
GitHub workflow upgrade

### DIFF
--- a/.github/workflows/npm-publish-github.yml
+++ b/.github/workflows/npm-publish-github.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/npm-publish-github.yml
+++ b/.github/workflows/npm-publish-github.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
       - uses: actions/setup-node@v3
         with:
           node-version: '12.x'

--- a/.github/workflows/npm-publish-github.yml
+++ b/.github/workflows/npm-publish-github.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '12.x'
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/npm-publish-github.yml
+++ b/.github/workflows/npm-publish-github.yml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@trisbee'
+          node-version: 16
+          registry-url: https://npm.pkg.github.com
+          scope: @trisbee
 
       - name: 'Publish library'
         run: npm publish --access public

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,7 +8,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: actions/setup-node@v1
               with:
                   node-version: '12.x'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
                   node-version: '12.x'
                   registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,8 +11,8 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: '12.x'
-                  registry-url: 'https://registry.npmjs.org'
+                  node-version: 16
+                  registry-url: https://registry.npmjs.org
 
             - name: 'Install dependencies'
               run: npm ci

--- a/.github/workflows/pull-request-created.yml
+++ b/.github/workflows/pull-request-created.yml
@@ -22,7 +22,7 @@ jobs:
             _You can watch progress on [build URL](${{ env.BUILD_URL }})_
 
       - name: 'Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: mansona/npm-lockfile-version@v1
 
       - name: 'Install dependencies'

--- a/.github/workflows/pull-request-created.yml
+++ b/.github/workflows/pull-request-created.yml
@@ -6,13 +6,16 @@ jobs:
   pull-request-created:
     name: 'Pull request created'
     runs-on: ubuntu-latest
+    permissions:
+        contents: write
+        id-token: write
+        pull-requests: write
     env:
         BUILD_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: 'Send working message to PR as comment'
-        uses: marocchino/sticky-pull-request-comment@v1
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           recreate: true
           message: |
             ⏳ Starting build, please wait ...
@@ -36,9 +39,8 @@ jobs:
 
       - name: 'The job has failed'
         if: ${{ failure() }}
-        uses: marocchino/sticky-pull-request-comment@v1
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           recreate: true
           message: |
             🔥 **Build failed**
@@ -55,9 +57,8 @@ jobs:
           path: ~/.npm/_logs
 
       - name: 'Send URL address to PR as comment'
-        uses: marocchino/sticky-pull-request-comment@v1
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           recreate: true
           message: |
             👍 **All good!**

--- a/.github/workflows/pull-request-created.yml
+++ b/.github/workflows/pull-request-created.yml
@@ -24,8 +24,11 @@ jobs:
 
             _You can watch progress on [build URL](${{ env.BUILD_URL }})_
 
-      - name: 'Checkout'
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+            node-version: 16
+
       - uses: mansona/npm-lockfile-version@v1
 
       - name: 'Install dependencies'


### PR DESCRIPTION
resolve warnings:

```
[Pull request created](https://github.com/trisbee/qr-image-nodejs/actions/runs/4202548552/jobs/7290834753)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: marocchino/sticky-pull-request-comment@v1, actions/checkout@v2, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

~~Upgrade runner env to node 16.x in next PR~~